### PR TITLE
Update frontend API config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ npx expo start
 Create a `.env.local` file in `frontend` to point the UI at your backend:
 
 ```
+# Local development
 NEXT_PUBLIC_API_BASE=http://localhost:5000/api
+
+# Production example
+# NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app/api
 ```
 
 ## 🔍 Hidden Fun

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app/api/scraper
+NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app/api

--- a/frontend/components/Donate.js
+++ b/frontend/components/Donate.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { FaDonate } from 'react-icons/fa';
+import Image from 'next/image';
 
 function Donate() {
   const [copied, setCopied] = useState(false);
@@ -116,9 +117,12 @@ function Donate() {
             </button>
           </div>
 
-          <img
+          <Image
             src={`https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${qrData}`}
             alt={`${currency.toUpperCase()} QR Code`}
+            width={150}
+            height={150}
+            unoptimized
             style={{ margin: '0 auto 1rem', borderRadius: '0.5rem' }}
           />
 

--- a/frontend/components/ResultCard.js
+++ b/frontend/components/ResultCard.js
@@ -9,11 +9,11 @@ export default function ResultCard({ item }) {
     <div className={styles.resultCard}>
       <div className={styles.cardImage}>
         <Image
-          src={image || '/fallback.jpg'}
+          src={image || '/chainsaw.gif'}
           alt={title || 'Chainsaw listing'}
           width={300}
           height={200}
-          objectFit="cover"
+          style={{ objectFit: 'cover' }}
         />
       </div>
       <div className={styles.cardBody}>

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    domains: ['i.dummyjson.com', 'api.qrserver.com'],
+  },
 };
 
 module.exports = nextConfig;

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,8 +1,10 @@
 import axios from 'axios';
 
 const API = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000/api',
-  withCredentials: true
+  baseURL:
+    process.env.NEXT_PUBLIC_API_BASE ||
+    'https://sawprice-hunter-backend-production.up.railway.app/api',
+  withCredentials: true,
 });
 
 export default API;


### PR DESCRIPTION
## Summary
- use production API as default in Axios helper
- adjust environment variable and docs
- allow remote images
- use fallback chainsaw gif when result item has no image
- convert QR code <img> to Next.js Image component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c769ffd2883259ff605b341d04ae9