### PR TITLE
Update frontend backend URL

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE=https://chainsaw-price-hunter-backend-production.up.railway.app/api
+NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app/api

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE || 'https://chainsaw-price-hunter-backend-production.up.railway.app/api'
+  baseURL:
+    process.env.NEXT_PUBLIC_API_BASE ||
+    'https://sawprice-hunter-backend-production.up.railway.app/api'
 });
 export default api;


### PR DESCRIPTION
## Summary
- update axios default URL to new backend domain
- adjust production env with the same URL

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850a57792c48325b5e35e0751418702