### PR TITLE
Fix API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Create a `.env.local` file in `frontend` to point the UI at your backend:
 NEXT_PUBLIC_API_BASE=http://localhost:5000/api
 
 # Production example
-# NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app/api
+# NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app
 ```
 
 ## 🔍 Hidden Fun

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app/api
+NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -42,7 +42,7 @@ export default function Home() {
     setError('');
 
     try {
-      const res = await API.get('/prices', {
+      const res = await API.get('/api/prices', {
         params: {
           query,
           region: selectedState,

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -2,6 +2,6 @@ import axios from 'axios';
 const api = axios.create({
   baseURL:
     process.env.NEXT_PUBLIC_API_BASE ||
-    'https://sawprice-hunter-backend-production.up.railway.app/api'
+    'https://sawprice-hunter-backend-production.up.railway.app'
 });
 export default api;


### PR DESCRIPTION
## Summary
- set `NEXT_PUBLIC_API_BASE` to production backend
- update axios base URL
- adjust price fetch path in the Next.js client

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850aaa4b2dc8325bfb5b231c403cfd2