### PR TITLE
Fix API base path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,15 @@ npm install
 npx expo start
 ```
 
-Create a `.env.local` file in `frontend` to point the UI at your backend:
+Copy `frontend/.env.example` to `frontend/.env.local` and point the UI at your backend:
 
 ```
 # Local development
-NEXT_PUBLIC_API_BASE=http://localhost:5000/api
+NEXT_PUBLIC_API_BASE=http://localhost:5000
 
 # Production example
-# NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app/api
+# NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app
+# (omit the trailing `/api`)
 ```
 
 ## 🔍 Hidden Fun

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+# Example environment for Chainsaw Price Hunter frontend
+# Set this to your backend base URL (omit trailing /api)
+NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app/api
+NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,6 +14,16 @@ pnpm dev
 bun dev
 ```
 
+### Environment variables
+
+Copy `.env.example` to `.env.local` and adjust `NEXT_PUBLIC_API_BASE` if needed:
+
+```bash
+cp .env.example .env.local
+# For production deployments, use your backend URL
+NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -42,7 +42,7 @@ export default function Home() {
     setError('');
 
     try {
-      const res = await API.get('/prices', {
+      const res = await API.get('/api/prices', {
         params: {
           query,
           region: selectedState,

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,7 +1,13 @@
 import axios from 'axios';
+
+const rawBase =
+  process.env.NEXT_PUBLIC_API_BASE ||
+  'https://sawprice-hunter-backend-production.up.railway.app';
+
+const baseURL = rawBase.replace(/\/api\/?$/, '').replace(/\/$/, '');
+
 const api = axios.create({
-  baseURL:
-    process.env.NEXT_PUBLIC_API_BASE ||
-    'https://sawprice-hunter-backend-production.up.railway.app/api'
+  baseURL
 });
+
 export default api;


### PR DESCRIPTION
## Summary
- normalize the API base URL to avoid double `/api` segments
- note in the docs that the production URL should omit `/api`
- add an example environment file and document how to configure `NEXT_PUBLIC_API_BASE`
- clarify README to copy `.env.example` and use `http://localhost:5000` during development

## Testing
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6850aaa4b2dc8325bfb5b231c403cfd2