### PR TITLE
Fix API base URL and improve setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ npm start
 cd frontend
 npm install
 npm run dev
+# If `next` is not found, ensure dependencies are installed with `npm install`
 
 # Mobile (requires Expo CLI)
 cd frontend-mobile
@@ -35,14 +36,15 @@ npm install
 npx expo start
 ```
 
-Create a `.env.local` file in `frontend` to point the UI at your backend:
+Copy `frontend/.env.example` to `frontend/.env.local` and point the UI at your backend:
 
 ```
 # Local development
-NEXT_PUBLIC_API_BASE=http://localhost:5000/api
+NEXT_PUBLIC_API_BASE=http://localhost:5000
 
 # Production example
-# NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app/api
+# NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app
+# (omit the trailing `/api`)
 ```
 
 ## 🔍 Hidden Fun

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+# Example environment for Chainsaw Price Hunter frontend
+# Set this to your backend base URL (omit trailing /api)
+NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app/api
+NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,9 +2,10 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+Install dependencies and run the development server:
 
 ```bash
+npm install
 npm run dev
 # or
 yarn dev
@@ -12,6 +13,16 @@ yarn dev
 pnpm dev
 # or
 bun dev
+```
+
+### Environment variables
+
+Copy `.env.example` to `.env.local` and adjust `NEXT_PUBLIC_API_BASE` if needed:
+
+```bash
+cp .env.example .env.local
+# For production deployments, use your backend URL
+NEXT_PUBLIC_API_BASE=https://sawprice-hunter-backend-production.up.railway.app
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -42,7 +42,7 @@ export default function Home() {
     setError('');
 
     try {
-      const res = await API.get('/prices', {
+      const res = await API.get('/api/prices', {
         params: {
           query,
           region: selectedState,

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,7 +1,13 @@
 import axios from 'axios';
+
+const rawBase =
+  process.env.NEXT_PUBLIC_API_BASE ||
+  'https://sawprice-hunter-backend-production.up.railway.app';
+
+const baseURL = rawBase.replace(/\/api\/?$/, '').replace(/\/$/, '');
+
 const api = axios.create({
-  baseURL:
-    process.env.NEXT_PUBLIC_API_BASE ||
-    'https://sawprice-hunter-backend-production.up.railway.app/api'
+  baseURL
 });
+
 export default api;


### PR DESCRIPTION
## Summary
- normalize the API base URL so users can omit `/api`
- add example environment file for the frontend
- update production env variable with the right URL
- document how to configure `NEXT_PUBLIC_API_BASE`
- ensure search requests hit `/api/prices`
- clarify that dependencies must be installed before running the frontend

## Testing
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6850aaa4b2dc8325bfb5b231c403cfd2