### PR TITLE
Handle missing Mongo URI gracefully

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -13,18 +13,20 @@ const PORT = process.env.PORT || 5000;
 const isProduction = process.env.NODE_ENV === 'production';
 
 // ✅ Connect to MongoDB using Mongoose
-const MONGO_URI = process.env.MONGO_URI || "mongodb+srv://rawfabricator:mongodmon@chainsawdb.6izrg.mongodb.net/?retryWrites=true&w=majority";
+const MONGO_URI = process.env.MONGO_URI;
 
 async function connectDB() {
+  if (!MONGO_URI) {
+    console.warn("⚠️ MONGO_URI not set. Running without database connectivity.");
+    return;
+  }
+
   try {
     await mongoose.connect(MONGO_URI);
     console.log("✅ Connected to MongoDB via Mongoose!");
   } catch (error) {
     console.error("❌ MongoDB connection error:", error);
-    // Don't exit in production, allow fallback
-    if (!isProduction) {
-      process.exit(1);
-    }
+    console.warn("⚠️ Continuing without MongoDB connection. Searches and alerts won't be persisted.");
   }
 }
 

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,10 +1,10 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 /* Custom fonts */
 @import url('https://fonts.googleapis.com/css2?family=Rajdhani:wght@300;400;500;600;700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap');
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 /* Global styles */
 * {


### PR DESCRIPTION
## Summary
- stop using a baked-in Mongo URI default and only attempt to connect when MONGO_URI is provided
- allow the backend server to continue running without MongoDB by logging warnings instead of exiting
- move Google Fonts @import statements to the top of the global stylesheet to comply with CSS rules

## Testing
- npm run lint (frontend)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69583afbe148832585a6ec53625a9e2c)